### PR TITLE
Remove version number and updated at and update by

### DIFF
--- a/openapi/components/responses/201.yaml
+++ b/openapi/components/responses/201.yaml
@@ -4,11 +4,11 @@ properties:
     $ref: ../schemas/service.yaml
 example: {
   metadata: {
-    "service_id": "1234",
+    "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
     "service_name": Service Name,
-    "version_id": "5678",
+    "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
     "created_at": "2020-10-09T11:51:46",
-    "created_by": "1234",
+    "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
     "configuration": {
       _id: service,
       _type: config.service

--- a/openapi/components/responses/201.yaml
+++ b/openapi/components/responses/201.yaml
@@ -7,7 +7,6 @@ example: {
     "service_id": "1234",
     "service_name": Service Name,
     "version_id": "5678",
-    "version_number": 1,
     "created_at": "2020-10-09T11:51:46",
     "created_by": "1234",
     "configuration": {

--- a/openapi/components/schemas/locales.yaml
+++ b/openapi/components/schemas/locales.yaml
@@ -13,6 +13,6 @@ items:
 example: [
   {
     "local": "cy",
-    "version_id": "1234"
+    "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267"
   }
 ]

--- a/openapi/components/schemas/locales.yaml
+++ b/openapi/components/schemas/locales.yaml
@@ -7,16 +7,12 @@ items:
       type: string
     version_id:
       type: string
-    version_number:
-      type: integer
   required:
     - locale
     - version_id
-    - version_number
 example: [
   {
     "local": "cy",
-    "version_id": "1234",
-    "version_number": 1
+    "version_id": "1234"
   }
 ]

--- a/openapi/components/schemas/service.yaml
+++ b/openapi/components/schemas/service.yaml
@@ -13,10 +13,6 @@ properties:
     description: Auto generated unique Hash id
     type: string
     example: "1234"
-  version_number:
-    description: Auto increment unique number for each service
-    type: integer
-    example: 1
   created_at:
     description: Date in ISO 8601 format
     type: string

--- a/openapi/components/schemas/service.yaml
+++ b/openapi/components/schemas/service.yaml
@@ -17,18 +17,10 @@ properties:
     description: Date in ISO 8601 format
     type: string
     example: "2020-10-09T11:51:46"
-  updated_at:
-    description: Date in ISO 8601 format
-    type: string
-    example: "2020-10-09T11:51:46"
   created_by:
     description: The ID of the User that created the Service
     type: string
     example: 4634ec01-5618-45ec-a4e2-bb5aa587e751
-  updated_by:
-    description: The ID of the User that last updated the Service
-    type: string
-    example: "5678"
   configuration:
     $ref: ./configuration.yaml
   global:
@@ -52,5 +44,3 @@ required:
   - pages
   - created_at
   - created_by
-  - updated_at
-  - updated_by

--- a/openapi/components/schemas/service.yaml
+++ b/openapi/components/schemas/service.yaml
@@ -4,7 +4,7 @@ properties:
   service_id:
     description: Service id
     type: integer
-    example: "1234"
+    example: 634aa3d5-a3b3-4d0f-9078-bb754542a1d3
   service_name:
     description: The name of the service
     type: string
@@ -12,7 +12,7 @@ properties:
   version_id:
     description: Auto generated unique Hash id
     type: string
-    example: "1234"
+    example: ac4b45c5-071e-4d07-b5a2-9f0196a5b267
   created_at:
     description: Date in ISO 8601 format
     type: string
@@ -24,7 +24,7 @@ properties:
   created_by:
     description: The ID of the User that created the Service
     type: string
-    example: "1234"
+    example: 4634ec01-5618-45ec-a4e2-bb5aa587e751
   updated_by:
     description: The ID of the User that last updated the Service
     type: string

--- a/openapi/components/schemas/service_payload.yaml
+++ b/openapi/components/schemas/service_payload.yaml
@@ -9,8 +9,6 @@ example: {
     "service_name": Service Name,
     "created_at": "2020-10-09T11:51:46",
     "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
-    "updated_at": "2020-10-09T11:51:46",
-    "updated_by": "1234",
     "configuration": {
       _id: service,
       _type: config.service

--- a/openapi/components/schemas/service_payload.yaml
+++ b/openapi/components/schemas/service_payload.yaml
@@ -8,7 +8,7 @@ example: {
   metadata: {
     "service_name": Service Name,
     "created_at": "2020-10-09T11:51:46",
-    "created_by": "1234",
+    "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
     "updated_at": "2020-10-09T11:51:46",
     "updated_by": "1234",
     "configuration": {

--- a/openapi/paths/service_versions.yaml
+++ b/openapi/paths/service_versions.yaml
@@ -29,12 +29,10 @@ get:
             service_id: 1234,
             versions: [
               {
-                version_number: 2,
                 version_id: 5678,
                 created_at: '2020-10-01'
               },
               {
-                version_number: 1,
                 version_id: 1234,
                 created_at: '2020-01-01'
               }

--- a/openapi/paths/service_versions.yaml
+++ b/openapi/paths/service_versions.yaml
@@ -26,14 +26,14 @@ get:
           type: object
           example: {
             service_name: Service Name,
-            service_id: 1234,
+            service_id: "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
             versions: [
               {
-                version_id: 5678,
+                version_id: "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
                 created_at: '2020-10-01'
               },
               {
-                version_id: 1234,
+                version_id: "06d18901-f0e2-409a-b2db-e323ce1a16db",
                 created_at: '2020-01-01'
               }
             ]

--- a/openapi/paths/services_user.yaml
+++ b/openapi/paths/services_user.yaml
@@ -23,11 +23,11 @@ get:
             services: [
               {
                 service_name: "basset",
-                service_id: 5678
+                service_id: "634aa3d5-a3b3-4d0f-9078-bb754542a1d3"
               },
               {
                 service_name: "starwars",
-                service_id: 1234
+                service_id: "634aa3d5-a3b3-4d0f-9078-bb754542a1d3"
               }
             ]
           }


### PR DESCRIPTION
## Remove version number

For the moment we do not feel we need to have to keep a record of the version number. If the design of the editor requires it in the future we can add it back in.

## Remove updated_at and updated_by

Since we are keeping entire versions of the metadata whenever something is created or edited created_at and created_by will always represent the last person to interact with the metadata.

Also use UUIDs as example IDs