### PR TITLE
Change the create service version endpoint

### DIFF
--- a/openapi/components/responses/422.yaml
+++ b/openapi/components/responses/422.yaml
@@ -1,12 +1,16 @@
 type: object
+description: The error messages that are returned for unprocessable entities
 properties:
-  status:
-    description: Response status code
-    type: string
-    minLength: 3
-    example: 422
   message:
     description: Response message
-    type: string
-    minLength: 1
-    example: Missing Service ID or Version ID
+    type: array
+    items:
+      type: string
+      minLength: 1
+      example: Service name or created by cannot be blank
+example: {
+  message: [
+    'Service name cannot be blank',
+    'Created by cannot be blank'
+  ]
+}

--- a/openapi/paths/service_version.yaml
+++ b/openapi/paths/service_version.yaml
@@ -43,9 +43,3 @@ get:
           application/json:
             schema:
               $ref: ../components/responses/404.yaml
-      '422':
-        description: Unprocessable Entity
-        content:
-          application/json:
-            schema:
-              $ref: ../components/responses/422.yaml

--- a/openapi/paths/service_versions.yaml
+++ b/openapi/paths/service_versions.yaml
@@ -1,3 +1,49 @@
+post:
+  tags:
+    - Services
+  summary: Create a new Service metadata version
+  description: Updates metadata for a given Service ID with a new version
+  operationId: create-service-version
+  parameters:
+  - name: service_id
+    in: path
+    description: The Service ID that needs to be updated
+    required: true
+    schema:
+      type: string
+  - name: locale
+    in: query
+    description: Optional. The locale of the metadata. Defaults to "en". Could be "cy"
+    schema:
+      type: string
+  security:
+    - jwt: []
+  responses:
+    '201':
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/responses/201.yaml
+    '401':
+      description: Authorisation information is missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: ../components/responses/401.yaml
+    '422':
+      description: Unprocessable Entity
+      content:
+        application/json:
+          schema:
+            $ref: ../components/responses/422.yaml
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/service_payload.yaml
+    required: true
+
 get:
   tags:
     - Services
@@ -50,9 +96,3 @@ get:
         application/json:
           schema:
             $ref: ../components/responses/404.yaml
-    '422':
-      description: Unprocessable Entity
-      content:
-        application/json:
-          schema:
-            $ref: ../components/responses/422.yaml

--- a/openapi/paths/services.yaml
+++ b/openapi/paths/services.yaml
@@ -19,34 +19,12 @@ post:
         application/json:
           schema:
             $ref: ../components/responses/401.yaml
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: ../components/schemas/service_payload.yaml
-    required: true
-
-put:
-  tags:
-    - Services
-  summary: Update Service metadata
-  description: Updates metadata for a given Service ID with a new version
-  operationId: update-service
-  security:
-    - jwt: []
-  responses:
-    '200':
-      description: OK
+    '422':
+      description: Unprocessable Entity
       content:
         application/json:
           schema:
-            $ref: ../components/responses/200.yaml
-    '401':
-      description: Authorisation information is missing or invalid
-      content:
-        application/json:
-          schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/422.yaml
   requestBody:
     content:
       application/json:

--- a/openapi/paths/services@{service_id}.yaml
+++ b/openapi/paths/services@{service_id}.yaml
@@ -37,9 +37,3 @@ get:
         application/json:
           schema:
             $ref: ../components/responses/404.yaml
-    '422':
-      description: Unprocessable Entity
-      content:
-        application/json:
-          schema:
-            $ref: ../components/responses/422.yaml

--- a/openapi/paths/services_user.yaml
+++ b/openapi/paths/services_user.yaml
@@ -37,12 +37,3 @@ get:
         application/json:
           schema:
             $ref: ../components/responses/401.yaml
-    '422':
-      description: Unprocessable Entity
-      content:
-        application/json:
-          type: object
-          example: {
-            "status": 422,
-            "message": "Missing User ID"
-          }


### PR DESCRIPTION
We have updated the create service version endpoint to be a PUT to the url `services/<service_id>/versions` as we felt this was a better representation of what the Metadata API is actually doing. It is creating a brand new version of the metadata in the DB.

We also removed some of the 422 responses from the GET requests.

https://trello.com/c/a4RisjKm/982-update-service-endpoint-service-versions

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>