### PR TITLE
Update response objects to not include metadata key

### DIFF
--- a/openapi/components/responses/200.yaml
+++ b/openapi/components/responses/200.yaml
@@ -1,7 +1,13 @@
 type: object
 properties:
-  message:
-    description: Response message
-    type: string
-    minLength: 1
-    example: New version created
+  $ref: ../schemas/service.yaml
+example: {
+  "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
+  "service_name": Service Name,
+  "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
+  "created_at": "2020-10-09T11:51:46",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {},
+  "pages": [],
+  "locale": "en"
+}

--- a/openapi/components/responses/201.yaml
+++ b/openapi/components/responses/201.yaml
@@ -1,25 +1,22 @@
 type: object
 properties:
-  metadata:
-    $ref: ../schemas/service.yaml
+  $ref: ../schemas/service.yaml
 example: {
-  metadata: {
-    "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
-    "service_name": Service Name,
-    "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
-    "created_at": "2020-10-09T11:51:46",
-    "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
-    "configuration": {
-      _id: service,
-      _type: config.service
-    },
-    "pages": [
-      {
-        "_id": "page.start",
-        "_type": "page.start",
-        "url": "/"
-      }
-    ],
-    "locale": "en"
-  }
+  "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
+  "service_name": Service Name,
+  "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
+  "created_at": "2020-10-09T11:51:46",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    _id: service,
+    _type: config.service
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "_type": "page.start",
+      "url": "/"
+    }
+  ],
+  "locale": "en"
 }


### PR DESCRIPTION
All responses from the metadata API will not wrap service or metadata
version objects in a separate metadata key. The entire metadata will be
the response object