### PR TITLE
Document 403 response instead of 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ get:
             type: array
             items:
               $ref: ../components/schemas/Customer.yaml
-    '401':
+    '403':
       $ref: ../components/responses/AccessForbidden.yaml
   x-code-samples:
     - lang: PHP
@@ -225,7 +225,7 @@ post:
   responses:
     '201':
       $ref: ../components/responses/Customer.yaml
-    '401':
+    '403':
       $ref: ../components/responses/AccessForbidden.yaml
     '409':
       $ref: ../components/responses/Conflict.yaml

--- a/openapi/paths/services.yaml
+++ b/openapi/paths/services.yaml
@@ -13,12 +13,12 @@ post:
         application/json:
           schema:
             $ref: ../components/responses/201.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml
     '422':
       description: Unprocessable Entity
       content:

--- a/openapi/paths/services@users@{user_id}.yaml
+++ b/openapi/paths/services@users@{user_id}.yaml
@@ -20,9 +20,9 @@ get:
         application/json:
           schema:
             $ref: ../components/responses/200_user_versions.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml

--- a/openapi/paths/services@{service_id}@versions.yaml
+++ b/openapi/paths/services@{service_id}@versions.yaml
@@ -25,12 +25,12 @@ post:
         application/json:
           schema:
             $ref: ../components/schemas/service.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml
     '422':
       description: Unprocessable Entity
       content:
@@ -71,12 +71,12 @@ get:
         application/json:
           schema:
             $ref: ../components/responses/200_versions.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml
     '404':
       description: Requested Service or Version not found
       content:

--- a/openapi/paths/services@{service_id}@versions@latest.yaml
+++ b/openapi/paths/services@{service_id}@versions@latest.yaml
@@ -25,12 +25,12 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/service.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml
     '404':
       description: Requested Service or Version not found
       content:

--- a/openapi/paths/services@{service_id}@versions@{version_id}.yaml
+++ b/openapi/paths/services@{service_id}@versions@{version_id}.yaml
@@ -26,12 +26,12 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/service.yaml
-    '401':
-      description: Authorisation information is missing or invalid
+    '403':
+      description: Not permitted to perform operation
       content:
         application/json:
           schema:
-            $ref: ../components/responses/401.yaml
+            $ref: ../components/responses/403.yaml
     '404':
       description: Requested Service or Version not found
       content:


### PR DESCRIPTION
In [this PR](https://github.com/ministryofjustice/fb-metadata-api/pull/60) we changed the API to return 403s instead of 401s.